### PR TITLE
Make method 'restCall' public

### DIFF
--- a/src/Freshdesk/Rest.php
+++ b/src/Freshdesk/Rest.php
@@ -71,7 +71,7 @@ class Rest
      * @throws \RuntimeException
      * @throws \InvalidArgumentException
      */
-    protected function restCall($urlMinusDomain, $method, $postData = '',$debugMode=false)
+    public function restCall($urlMinusDomain, $method, $postData = '',$debugMode=false)
     {
         if ($urlMinusDomain{0} !== '/')
             $urlMinusDomain = '/'.$urlMinusDomain;


### PR DESCRIPTION
Please consider to make method `restCall` public - it's well documented method and simple to use, and without this method we can't, for example, delete ticket. Such simple raw access to API is very useful.
