### PR TITLE
Add support for tags in the Ticket model

### DIFF
--- a/src/Freshdesk/CONTRIBUTORS.md
+++ b/src/Freshdesk/CONTRIBUTORS.md
@@ -1,0 +1,8 @@
+freshdesk-rest contributors (sorted alphabeticaly)
+============================================
+
+* **[Sam Wierema](https://github.com/samwierema)**
+
+  * Support for ticket tags
+
+**[Full contributors list](https://github.com/EVODelavega/freshdesk-rest/contributors).**

--- a/src/Freshdesk/Model/Ticket.php
+++ b/src/Freshdesk/Model/Ticket.php
@@ -102,9 +102,9 @@ class Ticket extends Base
     protected $ccEmailVal = null;
 
     /**
-     * @var string
+     * @var array
      */
-    protected $tags;
+    protected $tags = array();
 
     /**
      * @var array<CustomField>
@@ -383,15 +383,36 @@ class Ticket extends Base
     }
 
     /**
-     * Set any tags on the ticket
+     * Set multiple tags on the ticket
      *
-     * @param string $tags A comma-delimited string of tags
+     * @param mixed $tags Can be either an array, or a comma-delimited string of tags
      * @return $this
-     * @author Sam Wierema <sam@messagebird.com>
      */
     public function setTags($tags)
     {
-        $this->tags = (string) $tags;
+        if (is_string($tags)) {
+            $tags = explode(',', $tags);
+        }
+
+        if (is_array($tags)) {
+            $this->tags = $tags;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add a single tag to the ticket
+     *
+     * @param string $tag A single tag to add
+     * @return $this
+     */
+    public function addTag($tag)
+    {
+        if (is_string($tag)) {
+            $this->tags[] = $tag;
+        }
+
         return $this;
     }
 
@@ -399,11 +420,10 @@ class Ticket extends Base
      * Retrieve any tags set on the ticket
      *
      * @return string
-     * @author Sam Wierema <sam@messagebird.com>
      */
     public function getTags()
     {
-        return (string) $this->tags;
+        return implode(',', $this->tags);
     }
 
     /**

--- a/src/Freshdesk/Model/Ticket.php
+++ b/src/Freshdesk/Model/Ticket.php
@@ -102,6 +102,11 @@ class Ticket extends Base
     protected $ccEmailVal = null;
 
     /**
+     * @var string
+     */
+    protected $tags;
+
+    /**
      * @var array<CustomField>
      */
     protected $customField = array();

--- a/src/Freshdesk/Model/Ticket.php
+++ b/src/Freshdesk/Model/Ticket.php
@@ -502,16 +502,16 @@ class Ticket extends Base
      */
     public function toJsonData()
     {
-        $data = [
-            self::RESPONSE_KEY => [
+        $data = array(
+            self::RESPONSE_KEY => array(
                 'description'   => $this->description,
                 'subject'       => $this->subject,
                 'email'         => $this->email,
                 'priority'      => $this->priority,
                 'status'        => $this->status
-            ],
+            ),
             'cc_emails' => $this->getCcEmailVal()
-        ];
+        );
 
         $custom = [];
         $custom_fields = $this->getCustomFields();

--- a/src/Freshdesk/Model/Ticket.php
+++ b/src/Freshdesk/Model/Ticket.php
@@ -514,9 +514,9 @@ class Ticket extends Base
         );
 
         $custom = [];
-        $custom_fields = $this->getCustomFields();
+        $customFields = $this->getCustomFields();
         /** @var \Freshdesk\Model\CustomField $f */
-        foreach ($custom_fields as $f) {
+        foreach ($customFields as $f) {
             $custom[$f->getName(true)] = $f->getValue();
         }
 

--- a/src/Freshdesk/Model/Ticket.php
+++ b/src/Freshdesk/Model/Ticket.php
@@ -378,6 +378,30 @@ class Ticket extends Base
     }
 
     /**
+     * Set any tags on the ticket
+     *
+     * @param string $tags A comma-delimited string of tags
+     * @return $this
+     * @author Sam Wierema <sam@messagebird.com>
+     */
+    public function setTags($tags)
+    {
+        $this->tags = (string) $tags;
+        return $this;
+    }
+
+    /**
+     * Retrieve any tags set on the ticket
+     *
+     * @return string
+     * @author Sam Wierema <sam@messagebird.com>
+     */
+    public function getTags()
+    {
+        return (string) $this->tags;
+    }
+
+    /**
      * @param string $ccemail
      * @return $this
      */
@@ -473,36 +497,33 @@ class Ticket extends Base
      */
     public function toJsonData()
     {
-        $custom = array();
-        $fields = $this->getCustomFields();
+        $data = [
+            self::RESPONSE_KEY => [
+                'description'   => $this->description,
+                'subject'       => $this->subject,
+                'email'         => $this->email,
+                'priority'      => $this->priority,
+                'status'        => $this->status
+            ],
+            'cc_emails' => $this->getCcEmailVal()
+        ];
+
+        $custom = [];
+        $custom_fields = $this->getCustomFields();
         /** @var \Freshdesk\Model\CustomField $f */
-        foreach ($fields as $f)
+        foreach ($custom_fields as $f) {
             $custom[$f->getName(true)] = $f->getValue();
-        if (empty($custom))
-            return json_encode(
-                array(
-                    self::RESPONSE_KEY   => array(
-                        'description'   => $this->description,
-                        'subject'       => $this->subject,
-                        'email'         => $this->email,
-                        'priority'      => $this->priority,
-                        'status'        => $this->status
-                    ),
-                    'cc_emails' => $this->getCcEmailVal()
-                )
-            );
-        return json_encode(
-            array(
-                self::RESPONSE_KEY   => array(
-                    'description'   => $this->description,
-                    'subject'       => $this->subject,
-                    'email'         => $this->email,
-                    'priority'      => $this->priority,
-                    'status'        => $this->status,
-                    'custom_field'  => $custom
-                ),
-                'cc_emails' => $this->getCcEmailVal()
-            )
-        );
+        }
+
+        if (!empty($custom)) {
+            $data[self::RESPONSE_KEY]['custom_field'] = $custom;
+        }
+
+        $tags = $this->getTags();
+        if (!empty($tags)) {
+            $data['helpdesk']['tags'] = $tags;
+        }
+
+        return json_encode($data);
     }
 }

--- a/src/Freshdesk/Model/Ticket.php
+++ b/src/Freshdesk/Model/Ticket.php
@@ -533,7 +533,7 @@ class Ticket extends Base
             'cc_emails' => $this->getCcEmailVal()
         );
 
-        $custom = [];
+        $custom = array();
         $customFields = $this->getCustomFields();
         /** @var \Freshdesk\Model\CustomField $f */
         foreach ($customFields as $f) {


### PR DESCRIPTION
Freshdesk allows for tags to be attached when creating/updating a ticket. This pull request adds basic support for this feature. 

Note that I've used PHP's short notation for arrays, which makes the changes incompatible with PHP 5.3 (as listed in composer.json and .travis.yml), which is why the build is failing at this time. Let me know if you want me to revert it to the old array notation.